### PR TITLE
Intl - Internationalization

### DIFF
--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -1,20 +1,29 @@
-import type { FunctionComponent } from 'react'
 import { tw } from '@twind/core'
-import type { PropsWithTranslation, Translations } from '../hocs/withTranslation'
-import { withTranslation } from '../hocs/withTranslation'
-import { Language, useLanguage } from '../hooks/useLanguage'
+import { useTranslation } from '../hooks/useTranslation'
+import { useLanguage } from '../hooks/useLanguage'
+import type { Languages } from '../hooks/useLanguage'
 
 type LanguageSwitcherTranslation = {
   toggleLanguage: string
 }
 
+const defaultLanguageSwitcherTranslations: Record<Languages, LanguageSwitcherTranslation> = {
+  en: {
+    toggleLanguage: 'Toggle language',
+  },
+  de: {
+    toggleLanguage: 'Sprache wechseln',
+  }
+}
+
 // TODO: Basic and naive implementation of a LanguageSwitcher
-const LanguageSwitcher: FunctionComponent<PropsWithTranslation<LanguageSwitcherTranslation>> = ({ translation }) => {
+const LanguageSwitcher = () => {
   const { language, setLanguage } = useLanguage()
+  const translation = useTranslation(language, defaultLanguageSwitcherTranslations)
 
   const onClick = () => {
-    if (language === Language.DE) setLanguage(Language.EN)
-    if (language === Language.EN) setLanguage(Language.DE)
+    if (language === 'de') setLanguage('en')
+    if (language === 'en') setLanguage('de')
   }
 
   return (
@@ -22,13 +31,4 @@ const LanguageSwitcher: FunctionComponent<PropsWithTranslation<LanguageSwitcherT
   )
 }
 
-const defaultLanguageSwitcherTranslations: Translations<LanguageSwitcherTranslation> = {
-  [Language.EN]: {
-    toggleLanguage: 'Toggle language',
-  },
-  [Language.DE]: {
-    toggleLanguage: 'Sprache wechseln',
-  }
-}
-
-export default withTranslation(LanguageSwitcher, defaultLanguageSwitcherTranslations)
+export default LanguageSwitcher

--- a/app/components/examples/Title.tsx
+++ b/app/components/examples/Title.tsx
@@ -1,8 +1,8 @@
 import type { FunctionComponent } from 'react'
 import { tw } from '@twind/core'
-import type { PropsWithTranslation, Translations } from '../../hocs/withTranslation'
-import { withTranslation } from '../../hocs/withTranslation'
-import { Language } from '../../hooks/useLanguage'
+import { useTranslation } from '../../hooks/useTranslation'
+import type { PropsWithLanguage } from '../../hooks/useTranslation'
+import type { Languages } from '../../hooks/useLanguage'
 
 type TitleTranslation = {
   welcome: string,
@@ -10,33 +10,34 @@ type TitleTranslation = {
   page: (page: number) => string
 }
 
-type TitleProps = {
-  name: string
-}
-
-// Simple Title component to demonstrate some translations
-const Title: FunctionComponent<PropsWithTranslation<TitleTranslation, TitleProps>> = (props) => {
-  return (
-    <p className={tw('rounded bg-gray-800 text-gray-200 p-1 px-2')}>
-      {props.translation.welcome}{'! '}
-      {props.translation.goodToSeeYou}{', '}
-      <span className={tw('text-green-300')}>{props.name}</span>{'. '}
-      {props.translation.page(123)}
-    </p>
-  )
-}
-
-const defaultTitleTranslations: Translations<TitleTranslation> = {
-  [Language.EN]: {
+const defaultTitleTranslations: Record<Languages, TitleTranslation> = {
+  en: {
     welcome: 'Welcome',
     goodToSeeYou: 'Good to see you',
     page: (page) => `Page ${page}`
   },
-  [Language.DE]: {
+  de: {
     welcome: 'Willkommen',
     goodToSeeYou: 'Schön dich zu sehen',
     page: (page) => `Seite ${page}`
   }
 }
 
-export default withTranslation(Title, defaultTitleTranslations)
+type TitleProps = {
+  name: string
+}
+
+// Simple Title component to demonstrate some translations
+const Title: FunctionComponent<PropsWithLanguage<TitleTranslation, TitleProps>> = (props) => {
+  const translation = useTranslation(props.language, defaultTitleTranslations)
+  return (
+    <p className={tw('rounded bg-gray-800 text-gray-200 p-1 px-2')}>
+      {translation.welcome}{'! '}
+      {translation.goodToSeeYou}{', '}
+      <span className={tw('text-green-300')}>{props.name}</span>{'. '}
+      {translation.page(123)}
+    </p>
+  )
+}
+
+export default Title

--- a/app/hocs/withTranslation.tsx
+++ b/app/hocs/withTranslation.tsx
@@ -1,18 +1,20 @@
 import type { ComponentType } from 'react'
-import type { Language } from '../hooks/useLanguage'
+import type { Languages } from '../hooks/useLanguage'
 import { useLanguage } from '../hooks/useLanguage'
+import { useTranslation } from '../hooks/useTranslation'
 
-export type Translations<T> = Record<Language, T>
-export type PropsWithTranslation<T, P = unknown> = P & { translation: T }
-
-export const withTranslation = <Props, OwnTranslation>(
-  WrappedComponent: ComponentType<PropsWithTranslation<OwnTranslation, Props>>,
-  translations: Translations<OwnTranslation>
+/**
+ * This is a higher order component, which might have some problems with ref passing.
+ * Therefore it is recommended to use the `useTranslatino` hook instead.
+ * `useTranslation` is also used in the `withTranslation` hoc internally.
+ */
+export const withTranslation = <Props, OwnTranslation extends Record<string, unknown>>(
+  WrappedComponent: ComponentType<Props & { language: OwnTranslation }>,
+  translations: Record<Languages, OwnTranslation>
 ) => {
-  const ComponentWithTranslation = (props: Omit<Props, 'translation'>) => {
-    const { language } = useLanguage()
-    const translation = translations[language]
-    const mergedProps = { ...props, translation } as PropsWithTranslation<OwnTranslation, Props>
+  const ComponentWithTranslation = (props: Omit<Props, 'language'>) => {
+    const translation = useTranslation<OwnTranslation>(useLanguage().language, translations)
+    const mergedProps = { ...props, language: translation } as Props & { language: OwnTranslation }
     return <WrappedComponent {...mergedProps} />
   }
   return ComponentWithTranslation

--- a/app/hooks/useLanguage.tsx
+++ b/app/hooks/useLanguage.tsx
@@ -1,16 +1,14 @@
-import type { Dispatch, FunctionComponent, PropsWithChildren, SetStateAction } from 'react'
 import { createContext, useContext, useEffect, useState } from 'react'
+import type { Dispatch, FunctionComponent, PropsWithChildren, SetStateAction } from 'react'
 
-export enum Language {
-  EN = 'en-US',
-  DE = 'de-DE'
-}
+const languages = ['en', 'de'] as const
+export type Languages = typeof languages[number]
 
-export const DEFAULT_LANGUAGE = Language.DE
+export const DEFAULT_LANGUAGE = 'en'
 
 export type LanguageContextValue = {
-  language: Language,
-  setLanguage: Dispatch<SetStateAction<Language>>
+  language: Languages,
+  setLanguage: Dispatch<SetStateAction<Languages>>
 }
 
 export const LanguageContext = createContext<LanguageContextValue>({ language: DEFAULT_LANGUAGE, setLanguage: (v) => v })
@@ -18,22 +16,18 @@ export const LanguageContext = createContext<LanguageContextValue>({ language: D
 export const useLanguage = () => useContext(LanguageContext)
 
 export const ProvideLanguage: FunctionComponent<PropsWithChildren> = ({ children }) => {
-  const [language, setLanguage] = useState<Language>(DEFAULT_LANGUAGE)
+  const [language, setLanguage] = useState<Languages>(DEFAULT_LANGUAGE)
 
   useEffect(() => {
-    // TODO: this is one of the few places where unit tests would be useful
-    const languagesToTestAgainst: [string, Language][] = [
-      ...Object.values(Language).map(language => [language, language]) as [string, Language][],
-      ...Object.values(Language).map(language => [language.split('-')[0], language]) as [string, Language][]
-    ].sort((a, b) => b[0].localeCompare(a[0]))
+    const languagesToTestAgainst = Object.values(languages)
 
     const matchingBrowserLanguages = window.navigator.languages
-      .map(language => languagesToTestAgainst.find(([test]) => language === test))
-      .filter(entry => entry !== undefined) as [string, Language][]
+      .map(language => languagesToTestAgainst.find((test) => language === test || language.split('-')[0] === test))
+      .filter(entry => entry !== undefined)
 
     if (matchingBrowserLanguages.length === 0) return
 
-    const firstMatch = matchingBrowserLanguages[0][1]
+    const firstMatch = matchingBrowserLanguages[0] as Languages
     console.log(`setting language to: ${firstMatch}`)
     setLanguage(firstMatch)
   }, [])

--- a/app/hooks/useTranslation.ts
+++ b/app/hooks/useTranslation.ts
@@ -1,6 +1,19 @@
 import type { Languages } from '../hooks/useLanguage'
 import { useLanguage, DEFAULT_LANGUAGE } from '../hooks/useLanguage'
 
+/**
+ * Adds the `language` prop to the component props.
+ *
+ * @param Translation the type of the translation object
+ *
+ * @param Props the type of the component props, defaults to `Record<string, never>`,
+ *              if you don't expect any other props other than `language` and get an
+ *              error when using your component (because it uses `forwardRef` etc.)
+ *              you can try out `Record<string, unknown>`, this might resolve your
+ *              problem as `SomeType & never` is still `never` but `SomeType & unknown`
+ *              is `SomeType` which means that adding back props (like `ref` etc.)
+ *              works properly
+ */
 export type PropsWithLanguage<Translation, Props = Record<string, never>> = Props & {
   language?: Partial<Translation> | Languages
 }

--- a/app/hooks/useTranslation.ts
+++ b/app/hooks/useTranslation.ts
@@ -1,0 +1,20 @@
+import type { Languages } from '../hooks/useLanguage'
+import { useLanguage, DEFAULT_LANGUAGE } from '../hooks/useLanguage'
+
+export type PropsWithLanguage<Translation, Props = Record<string, never>> = Props & {
+  language?: Partial<Translation> | Languages
+}
+
+export const useTranslation = <Language extends Record<string, unknown>>(
+  languageProp: PropsWithLanguage<Language>['language'],
+  defaults: Record<Languages, Language>
+) => {
+  const { language: inferredLanguage } = useLanguage()
+  if (languageProp === undefined) {
+    return defaults[inferredLanguage]
+  } else if (typeof languageProp !== 'object') {
+    return defaults[languageProp as Languages]
+  } else {
+    return Object.assign(defaults[DEFAULT_LANGUAGE], languageProp as Partial<Language>)
+  }
+}

--- a/app/pages/login.tsx
+++ b/app/pages/login.tsx
@@ -9,9 +9,9 @@ import { loginWithCredentials } from '../utils/login'
 import { Input } from '../components/Input'
 import { Checkbox } from '../components/Checkbox'
 import { Button } from '../components/Button'
-import { Language } from '../hooks/useLanguage'
-import { withTranslation } from '../hocs/withTranslation'
-import type { Translations, PropsWithTranslation } from '../hocs/withTranslation'
+import type { Languages } from '../hooks/useLanguage'
+import { useTranslation } from '../hooks/useTranslation'
+import type { PropsWithLanguage } from '../hooks/useTranslation'
 
 import HelpwaveLogo from '../icons/Helpwave'
 
@@ -29,8 +29,8 @@ type LoginTranslation = {
   signIn: string
 }
 
-const defaultLoginTranslation: Translations<LoginTranslation> = {
-  [Language.EN]: {
+const defaultLoginTranslation: Record<Languages, LoginTranslation> = {
+  en: {
     signInHeader: 'Sign in to your organization',
     contactSubheader: {
       or: 'Or ',
@@ -43,7 +43,7 @@ const defaultLoginTranslation: Translations<LoginTranslation> = {
     forgotPassword: 'Forgot your password?',
     signIn: 'Sign in'
   },
-  [Language.DE]: {
+  de: {
     signInHeader: 'Melden Sie sich bei Ihrer Organisation an',
     contactSubheader: {
       or: 'Oder ',
@@ -58,8 +58,9 @@ const defaultLoginTranslation: Translations<LoginTranslation> = {
   }
 }
 
-const LoginPage: NextPage<PropsWithTranslation<LoginTranslation>> = ({ translation }) => {
+const LoginPage: NextPage<PropsWithLanguage<LoginTranslation>> = (props) => {
   const router = useRouter()
+  const translation = useTranslation(props.language, defaultLoginTranslation)
   const [rememberMe, setRememberMe] = useState(false)
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -135,4 +136,4 @@ const LoginPage: NextPage<PropsWithTranslation<LoginTranslation>> = ({ translati
   )
 }
 
-export default withTranslation(LoginPage, defaultLoginTranslation)
+export default LoginPage

--- a/landing-page/components/sections/ContactSection.tsx
+++ b/landing-page/components/sections/ContactSection.tsx
@@ -8,8 +8,49 @@ import { Toast } from '../Toast'
 import Send from '../../icons/Send'
 import AlertCircle from '../../icons/AlertCircle'
 import { hubspotSubmitForm } from '../../utils/hubspot'
+import { useTranslation } from '../../hooks/useTranslation'
+import type { PropsWithLanguage } from '../../hooks/useTranslation'
+import type { Languages } from '../../hooks/useLanguage'
 
-const ContactSection = forwardRef<HTMLDivElement>(function ContactSection(_, ref) {
+type ContactSectionLanguage = {
+  heading: string,
+  yourInformation: string,
+  email: string,
+  firstName: string,
+  lastName: string,
+  message: string,
+  send: string,
+  successMessage: string,
+  failureMessage: string,
+}
+
+const defaultContactSectionTranslations: Record<Languages, ContactSectionLanguage> = {
+  en: {
+    heading: 'Contact',
+    yourInformation: 'Your Information',
+    email: 'Email',
+    firstName: 'First name',
+    lastName: 'Last name',
+    message: 'Message',
+    send: 'Send',
+    successMessage: 'Message sent!',
+    failureMessage: 'Something went wrong!'
+  },
+  de: {
+    heading: 'Kontakt',
+    yourInformation: 'DE: Your Information', // TODO: translate (in a nice sounding way; not "Ihre/Deine Informationen")
+    email: 'Email',
+    firstName: 'Vorname',
+    lastName: 'Nachname',
+    message: 'Nachricht',
+    send: 'Abschicken',
+    successMessage: 'Nachricht gesendet!',
+    failureMessage: 'Es ist ein Fehler aufgetreten!'
+  }
+}
+
+const ContactSection = forwardRef<HTMLDivElement, PropsWithLanguage<ContactSectionLanguage>>(function ContactSection(props, ref) {
+  const language = useTranslation(props.language, defaultContactSectionTranslations)
   const [email, setEmail] = useState('')
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
@@ -31,37 +72,37 @@ const ContactSection = forwardRef<HTMLDivElement>(function ContactSection(_, ref
           setLastName('')
           setMessage('')
 
-          toast.custom(<Toast message="Message sent!" theme="dark" variant="primary" icon={<Send width={20} height={24} />} />, { position: 'bottom-left', duration: 1000 })
+          toast.custom(<Toast message={language.successMessage} theme="dark" variant="primary" icon={<Send width={20} height={24} />} />, { position: 'bottom-left', duration: 1000 })
         })
         .catch((error) => {
           console.error(error)
-          toast.custom(<Toast message="Something went wrong" theme="dark" variant="negative" icon={<AlertCircle />} />, { position: 'bottom-left', duration: 5000 })
+          toast.custom(<Toast message={language.failureMessage} theme="dark" variant="negative" icon={<AlertCircle />} />, { position: 'bottom-left', duration: 5000 })
         })
     }
   }
 
   return (
-    <TitleSection id="contact" ref={ref} title="Contact">
+    <TitleSection id="contact" ref={ref} title={language.heading}>
       <form onSubmit={handleSubmit}>
         <span className={tw('block font-medium text-white')}>Your Information</span>
 
         <div className={tw('flex w-96')}>
-          <Input id="contact-us-email" group={['bottom']} label="Email" placeholder="Email" type="email" value={email} onChange={setEmail} />
+          <Input id="contact-us-email" group={['bottom']} label={language.email} placeholder={language.email} type="email" value={email} onChange={setEmail} />
         </div>
         <div className={tw('flex w-96')}>
-          <Input id="contact-us-first-name" group={['top', 'right']} label="First name" placeholder="First name" type="text" value={firstName} onChange={setFirstName} />
-          <Input id="contact-us-last-name" group={['top', 'left']} label="Last name" placeholder="Last name" type="text" value={lastName} onChange={setLastName} />
+          <Input id="contact-us-first-name" group={['top', 'right']} label={language.firstName} placeholder={language.firstName} type="text" value={firstName} onChange={setFirstName} />
+          <Input id="contact-us-last-name" group={['top', 'left']} label={language.lastName} placeholder={language.lastName} type="text" value={lastName} onChange={setLastName} />
         </div>
 
         <br />
 
-        <span className={tw('block font-medium text-white')}>Message</span>
+        <span className={tw('block font-medium text-white')}>{language.message}</span>
         <div className={tw('flex w-96')}>
           <textarea className={tw('mt-1 block w-full h-48 bg-hw-dark-gray-800 placeholder:text-[#8E8E93] border-2 border-hw-primary-700 rounded-md shadow-sm focus:outline-none focus:border-indigo-500 focus:ring-indigo-500')} value={message} onChange={(e) => setMessage(e.target.value)} />
         </div>
 
         <button type="submit" className={tw('mt-2 py-1 px-4 flex border-2 border-hw-primary-700 rounded-md space-x-2')}>
-          <span>Send</span>
+          <span>{language.send}</span>
           <Send width={20} height={24} />
         </button>
       </form>

--- a/landing-page/components/sections/ContactSection.tsx
+++ b/landing-page/components/sections/ContactSection.tsx
@@ -49,7 +49,7 @@ const defaultContactSectionTranslations: Record<Languages, ContactSectionLanguag
   }
 }
 
-const ContactSection = forwardRef<HTMLDivElement, PropsWithLanguage<ContactSectionLanguage>>(function ContactSection(props, ref) {
+const ContactSection = forwardRef<HTMLDivElement, PropsWithLanguage<ContactSectionLanguage, Record<string, unknown>>>(function ContactSection(props, ref) {
   const language = useTranslation(props.language, defaultContactSectionTranslations)
   const [email, setEmail] = useState('')
   const [firstName, setFirstName] = useState('')

--- a/landing-page/components/sections/FeaturesSection.tsx
+++ b/landing-page/components/sections/FeaturesSection.tsx
@@ -2,37 +2,54 @@ import { forwardRef } from 'react'
 import { Section } from '../Section'
 import { tw, tx } from '@twind/core'
 import { Checkbox } from '../Checkbox'
+import { useTranslation } from '../../hooks/useTranslation'
+import type { PropsWithLanguage } from '../../hooks/useTranslation'
+import type { Languages } from '../../hooks/useLanguage'
 
-const featuresDe = [
-  { title: 'Intuitiv', detail: 'Keine Einarbeitung, keine Handbücher. Anmelden, loslegen. Sicher durch den Klinikalltag und pünktlicher in den Feierabend. Mehr Zeit für die Dinge auf die es ankommt.' },
-  { title: 'Kollaborativ', detail: 'Kein Telefon mehr, erst Recht kein Faxgerät. Einfache Teamorganisation auf einer gemeinsamen Plattform. Teilbare SOPs über das gesamte Team. Egal von wo, egal wann.' },
-  { title: 'Praxisnah', detail: 'Echte Lösungen für echte Menschen. Entwickelt mit dem Personal vor Ort um ihnen die Lösungen zu liefern die sie immer wollten, aber nie bekommen haben.' },
-  { title: 'Sicherheit', detail: 'Standardisiertes Arbeiten. Kein Vergessen mehr von Aufgaben. Kein Verlieren der Stationsliste. Mehr Sicherheit für Patient:innen, ein besseres Gefühl für Mitarbeitende.' },
-]
+export type FeaturesSectionLanguage = {
+  heading: string,
+  features: { title: string, details: string }[]
+}
 
-const featuresEn = [
-  { title: 'Intuitive', detail: 'No training, no manuals. Sign up, get started. Safely through the clinical every day and less overtime. More time for the things that matter.' },
-  { title: 'Collaborative', detail: 'No more phone calls, no fax machines. Easy to use team organization on a single platform. Shareable SOPs across the entire team. No matter where, no matter when.' },
-  { title: 'Real Life', detail: 'Real solutions for real people. Developed with the staff on site to give them the solutions they always wanted, but never got.' },
-  { title: 'Security', detail: "Standardized work. No more forgetting tasks. No more losing the ward's list. More security for patients, a better feeling for the staff." },
-]
+const defaultFeaturesSectionLanguage: Record<Languages, FeaturesSectionLanguage> = {
+  en: {
+    heading: 'Solve real world problems',
+    features: [
+      { title: 'Intuitive', details: 'No training, no manuals. Sign up, get started. Safely through the clinical every day and less overtime. More time for the things that matter.' },
+      { title: 'Collaborative', details: 'No more phone calls, no fax machines. Easy to use team organization on a single platform. Shareable SOPs across the entire team. No matter where, no matter when.' },
+      { title: 'Real Life', details: 'Real solutions for real people. Developed with the staff on site to give them the solutions they always wanted, but never got.' },
+      { title: 'Security', details: "Standardized work. No more forgetting tasks. No more losing the ward's list. More security for patients, a better feeling for the staff." },
+    ]
+  },
+  de: {
+    heading: 'DE: Solve real world problems', // TODO: translate
+    features: [
+      { title: 'Intuitiv', details: 'Keine Einarbeitung, keine Handbücher. Anmelden, loslegen. Sicher durch den Klinikalltag und pünktlicher in den Feierabend. Mehr Zeit für die Dinge auf die es ankommt.' },
+      { title: 'Kollaborativ', details: 'Kein Telefon mehr, erst Recht kein Faxgerät. Einfache Teamorganisation auf einer gemeinsamen Plattform. Teilbare SOPs über das gesamte Team. Egal von wo, egal wann.' },
+      { title: 'Praxisnah', details: 'Echte Lösungen für echte Menschen. Entwickelt mit dem Personal vor Ort um ihnen die Lösungen zu liefern die sie immer wollten, aber nie bekommen haben.' },
+      { title: 'Sicherheit', details: 'Standardisiertes Arbeiten. Kein Vergessen mehr von Aufgaben. Kein Verlieren der Stationsliste. Mehr Sicherheit für Patient:innen, ein besseres Gefühl für Mitarbeitende.' },
+    ]
+  }
+}
 
-const Feature = ({ title, detail }: { title: string, detail: string }) => (
+const Feature = ({ title, details }: { title: string, details: string }) => (
   <div className={tw('flex flex-row items-start text-xl')}>
     <Checkbox checked={true} onChange={() => undefined} disabled id={`feature-${title}`} label="" />
     <span className={tw('font-medium text-white text-xl')}>
-      {title} <span className={tw(`font-normal text-gray-400`)}>{detail}</span>
+      {title} <span className={tw(`font-normal text-gray-400`)}>{details}</span>
     </span>
   </div>
 )
 
-const FeaturesSection = forwardRef<HTMLDivElement>(function FeaturesSection(_, ref) {
+const FeaturesSection = forwardRef<HTMLDivElement, PropsWithLanguage<FeaturesSectionLanguage>>(function FeaturesSection(props, ref) {
+  const language = useTranslation(props.language, defaultFeaturesSectionLanguage)
+
   return (
     <div className={tw('relative')} id="features">
       <Section ref={ref} id="features">
-        <h1 className={tw('text-5xl font-space font-bold pb-4')}>Solve real world problems</h1>
+        <h1 className={tw('text-5xl font-space font-bold pb-4')}>{language.heading}</h1>
         <div className={tw('w-5/12 flex flex-col my-24')}>
-          {featuresDe.map((value, index) => (
+          {language.features.map((value, index) => (
             <div key={index} className={tx('w-9/12 flex flex-col my-8', {
               'self-end mr-8': index % 2 === 0,
               'self-start ml-8': index % 2 === 1

--- a/landing-page/components/sections/FeaturesSection.tsx
+++ b/landing-page/components/sections/FeaturesSection.tsx
@@ -41,7 +41,7 @@ const Feature = ({ title, details }: { title: string, details: string }) => (
   </div>
 )
 
-const FeaturesSection = forwardRef<HTMLDivElement, PropsWithLanguage<FeaturesSectionLanguage>>(function FeaturesSection(props, ref) {
+const FeaturesSection = forwardRef<HTMLDivElement, PropsWithLanguage<FeaturesSectionLanguage, Record<string, unknown>>>(function FeaturesSection(props, ref) {
   const language = useTranslation(props.language, defaultFeaturesSectionLanguage)
 
   return (

--- a/landing-page/components/sections/PartnerSection.tsx
+++ b/landing-page/components/sections/PartnerSection.tsx
@@ -4,6 +4,9 @@ import { TitleSection } from '../Section'
 import StadtWarendorf from '../../icons/partners/StadtWarendorf'
 import Ukm from '../../icons/partners/ukm'
 import MSHack from '../../icons/partners/MSHack'
+import { useTranslation } from '../../hooks/useTranslation'
+import type { PropsWithLanguage } from '../../hooks/useTranslation'
+import type { Languages } from '../../hooks/useLanguage'
 
 const partners = [
   { name: 'Muensterhack', Icon: MSHack, url: 'https://www.muensterhack.de/' },
@@ -11,9 +14,23 @@ const partners = [
   { name: 'Stadt Warendorf', Icon: StadtWarendorf, url: 'https://www.warendorf.de/' },
 ]
 
-const PartnerSection = forwardRef<HTMLDivElement>(function PartnerSection(_, ref) {
+export type PartnerSectionLanguage = {
+  heading: string
+}
+
+const defaultPartnerSectionTranslations: Record<Languages, PartnerSectionLanguage> = {
+  en: {
+    heading: 'Our Partners',
+  },
+  de: {
+    heading: 'Unsere Partner',
+  }
+}
+
+const PartnerSection = forwardRef<HTMLDivElement, PropsWithLanguage<PartnerSectionLanguage>>(function PartnerSection(props, ref) {
+  const language = useTranslation(props.language, defaultPartnerSectionTranslations)
   return (
-    <TitleSection id="partner" ref={ref} title="Our Partners">
+    <TitleSection id="partner" ref={ref} title={language.heading}>
       <div className={tw('flex gap-4 pt-4')}>
       {partners.map((partner) => (
         <a key={partner.name} href={partner.url} target="_blank" rel="noopener noreferrer">

--- a/landing-page/components/sections/PartnerSection.tsx
+++ b/landing-page/components/sections/PartnerSection.tsx
@@ -27,7 +27,7 @@ const defaultPartnerSectionTranslations: Record<Languages, PartnerSectionLanguag
   }
 }
 
-const PartnerSection = forwardRef<HTMLDivElement, PropsWithLanguage<PartnerSectionLanguage>>(function PartnerSection(props, ref) {
+const PartnerSection = forwardRef<HTMLDivElement, PropsWithLanguage<PartnerSectionLanguage, Record<string, unknown>>>(function PartnerSection(props, ref) {
   const language = useTranslation(props.language, defaultPartnerSectionTranslations)
   return (
     <TitleSection id="partner" ref={ref} title={language.heading}>

--- a/landing-page/components/sections/RoadmapSection.tsx
+++ b/landing-page/components/sections/RoadmapSection.tsx
@@ -14,7 +14,7 @@ const defaultRoadmapSectionTranslations: Record<Languages, RoadmapSectionLanguag
     heading: 'Roadmap',
   },
   de: {
-    heading: 'DE: Roadmap', // TODO: translate (or do we want to leave it in english as is?)
+    heading: 'Roadmap',
   }
 }
 

--- a/landing-page/components/sections/RoadmapSection.tsx
+++ b/landing-page/components/sections/RoadmapSection.tsx
@@ -1,10 +1,27 @@
 import { forwardRef } from 'react'
 import { tw } from '@twind/core'
 import { TitleSection } from '../Section'
+import { useTranslation } from '../../hooks/useTranslation'
+import type { PropsWithLanguage } from '../../hooks/useTranslation'
+import type { Languages } from '../../hooks/useLanguage'
 
-const RoadmapSection = forwardRef<HTMLDivElement>(function RoadmapSection(_, ref) {
+export type RoadmapSectionLanguage = {
+  heading: string
+}
+
+const defaultRoadmapSectionTranslations: Record<Languages, RoadmapSectionLanguage> = {
+  en: {
+    heading: 'Roadmap',
+  },
+  de: {
+    heading: 'DE: Roadmap', // TODO: translate (or do we want to leave it in english as is?)
+  }
+}
+
+const RoadmapSection = forwardRef<HTMLDivElement, PropsWithLanguage<RoadmapSectionLanguage>>(function RoadmapSection(props, ref) {
+  const language = useTranslation(props.language, defaultRoadmapSectionTranslations)
   return (
-    <TitleSection id="roadmap" ref={ref} title="Roadmap">
+    <TitleSection id="roadmap" ref={ref} title={language.heading}>
 
     </TitleSection>
   )

--- a/landing-page/components/sections/RoadmapSection.tsx
+++ b/landing-page/components/sections/RoadmapSection.tsx
@@ -18,7 +18,7 @@ const defaultRoadmapSectionTranslations: Record<Languages, RoadmapSectionLanguag
   }
 }
 
-const RoadmapSection = forwardRef<HTMLDivElement, PropsWithLanguage<RoadmapSectionLanguage>>(function RoadmapSection(props, ref) {
+const RoadmapSection = forwardRef<HTMLDivElement, PropsWithLanguage<RoadmapSectionLanguage, Record<string, unknown>>>(function RoadmapSection(props, ref) {
   const language = useTranslation(props.language, defaultRoadmapSectionTranslations)
   return (
     <TitleSection id="roadmap" ref={ref} title={language.heading}>

--- a/landing-page/components/sections/StartSection.tsx
+++ b/landing-page/components/sections/StartSection.tsx
@@ -65,7 +65,7 @@ const defaultStartSectionLanguage: Record<Languages, StartSectionLanguage> = {
   }
 }
 
-const StartSection = forwardRef<HTMLDivElement, PropsWithLanguage<StartSectionLanguage>>(function StartSection(props, ref) {
+const StartSection = forwardRef<HTMLDivElement, PropsWithLanguage<StartSectionLanguage, Record<string, unknown>>>(function StartSection(props, ref) {
   const language = useTranslation(props.language, defaultStartSectionLanguage)
   return (
     <div className={tw('w-full h-screen bg-hw-dark-gray-600 text-white')} id="start" ref={ref}>

--- a/landing-page/components/sections/StartSection.tsx
+++ b/landing-page/components/sections/StartSection.tsx
@@ -1,34 +1,72 @@
 import { forwardRef } from 'react'
+import type { FC as ReactFC } from 'react'
 import { tw } from '@twind/core'
 import Header from '../Header'
 import Helpwave from '../../icons/HelpwaveRect'
 import { Checkbox } from '../Checkbox'
+import type { Languages } from '../../hooks/useLanguage'
+import { useTranslation } from '../../hooks/useTranslation'
+import type { PropsWithLanguage } from '../../hooks/useTranslation'
 
-const HeroMessageDe = () => (
-  <>
-    {'Bei helpwave entwickeln wir keine Software für das Gesundheitssystem, sondern mit ihm. '}<br />
-    {'In diesem Zusammenschluss aus Ärzten, Entwicklern und weiteren frischen Geistern, '}<br />
-    {'entstehen '}
-    <span className={tw('text-hw-primary-400')}>{'echte'}</span>
-    {' Lösungen für '}
-    <span className={tw('text-hw-pool-red')}>{'echte'}</span>
-    {' Menschen.'}
-  </>
-)
+export type StartSectionLanguage = {
+  HeroMessageComponent: ReactFC,
+  features: {
+    intuitive: string,
+    collaborative: string,
+    practical: string,
+    secure: string,
+    interdisciplinary: string,
+    openSource: string
+  }
+}
 
-const HeroMessageEn = () => (
-  <>
-    {"At helpwave, we don't see information technology"}<br />
-    {'as an old marriage that has fallen asleep, but as'}<br />
-    {'a '}
-    <span className={tw('text-hw-primary-400')}>{'newly'}</span>
-    {' & '}
-    <span className={tw('text-hw-pool-red')}>{'rekindled'}</span>
-    {' hot affair'}
-  </>
-)
+const defaultStartSectionLanguage: Record<Languages, StartSectionLanguage> = {
+  en: {
+    HeroMessageComponent: () => (
+      <>
+        {"At helpwave, we don't see information technology"}<br />
+        {'as an old marriage that has fallen asleep, but as'}<br />
+        {'a '}
+        <span className={tw('text-hw-primary-400')}>{'newly'}</span>
+        {' & '}
+        <span className={tw('text-hw-pool-red')}>{'rekindled'}</span>
+        {' hot affair'}
+      </>
+    ),
+    features: {
+      intuitive: 'Intuitive',
+      collaborative: 'Collaborative',
+      practical: 'Practical',
+      secure: 'Secure',
+      interdisciplinary: 'Interdisciplinary',
+      openSource: 'Open Source'
+    }
+  },
+  de: {
+    HeroMessageComponent: () => (
+      <>
+        {'Bei helpwave entwickeln wir keine Software für das Gesundheitssystem, sondern mit ihm. '}<br />
+        {'In diesem Zusammenschluss aus Ärzten, Entwicklern und weiteren frischen Geistern, '}<br />
+        {'entstehen '}
+        <span className={tw('text-hw-primary-400')}>{'echte'}</span>
+        {' Lösungen für '}
+        <span className={tw('text-hw-pool-red')}>{'echte'}</span>
+        {' Menschen.'}
+      </>
+    ),
+    features: {
+      intuitive: 'Intuitiv',
+      collaborative: 'Kollaborativ',
+      practical: 'Praxisnah',
+      secure: 'Sicher',
+      interdisciplinary: 'Interprofessionell',
+      openSource: 'Open Source'
+    }
+  }
+}
 
-const StartSection = forwardRef<HTMLDivElement>(function StartSection(_, ref) {
+const StartSection = forwardRef<HTMLDivElement, PropsWithLanguage<StartSectionLanguage>>(function StartSection(props, ref) {
+  const language = useTranslation(props.language, defaultStartSectionLanguage)
   return (
     <div className={tw('w-full h-screen bg-hw-dark-gray-600 text-white')} id="start" ref={ref}>
       <div className={tw('py-8 px-16')}>
@@ -41,19 +79,19 @@ const StartSection = forwardRef<HTMLDivElement>(function StartSection(_, ref) {
         </div>
 
         <div className={tw('font-sans text-2xl font-medium mt-4')}>
-          <HeroMessageDe />
+          <language.HeroMessageComponent />
         </div>
 
         <div className={tw('p-4 flex gap-16')}>
           <div className={tw('flex flex-col')}>
-            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-1" label="Intuitiv" /></div>
-            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-2" label="Kollaborativ" /></div>
-            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-3" label="Praxisnah" /></div>
+            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-1" label={language.features.intuitive} /></div>
+            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-2" label={language.features.collaborative} /></div>
+            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-3" label={language.features.practical} /></div>
           </div>
           <div className={tw('flex flex-col')}>
-            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-4" label="Sicher" /></div>
-            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-5" label="Interprofessionell" /></div>
-            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-6" label="Open-Source" /></div>
+            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-4" label={language.features.secure} /></div>
+            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-5" label={language.features.interdisciplinary} /></div>
+            <div className={tw('p-2')}><Checkbox checked={true} onChange={() => undefined} disabled id="feature-6" label={language.features.openSource} /></div>
           </div>
         </div>
       </div>

--- a/landing-page/components/sections/TeamSection.tsx
+++ b/landing-page/components/sections/TeamSection.tsx
@@ -53,7 +53,7 @@ const Person = ({ name, role }: { name: string, role: Role }) => (
   </div>
 )
 
-const TeamSection = forwardRef<HTMLDivElement, PropsWithLanguage<TeamSectionLanguage>>(function TeamSection(props, ref) {
+const TeamSection = forwardRef<HTMLDivElement, PropsWithLanguage<TeamSectionLanguage, Record<string, unknown>>>(function TeamSection(props, ref) {
   const language = useTranslation(props.language, defaultTeamSectionTranslations)
   return (
     <Section ref={ref} id="team">

--- a/landing-page/components/sections/TeamSection.tsx
+++ b/landing-page/components/sections/TeamSection.tsx
@@ -2,6 +2,9 @@ import { forwardRef } from 'react'
 import { tw } from '@twind/core'
 import GridBox from '../GridBox'
 import { Section } from '../Section'
+import { useTranslation } from '../../hooks/useTranslation'
+import type { PropsWithLanguage } from '../../hooks/useTranslation'
+import type { Languages } from '../../hooks/useLanguage'
 
 const roles = { /* eslint-disable key-spacing, no-multi-spaces */
   FRONTEND_DEVELOPER: { id: 'FRONTEND_DEVELOPER', name: 'Frontend Developer', color: 'hw-primary-300' },
@@ -28,6 +31,19 @@ const teamMembers = [ /* eslint-disable key-spacing, no-multi-spaces */
   { name: 'Nico',      role: roleEnum.DEVOPS }
 ] /* eslint-enable key-spacing, no-multi-spaces */
 
+export type TeamSectionLanguage = {
+  heading: string
+}
+
+const defaultTeamSectionTranslations: Record<Languages, TeamSectionLanguage> = {
+  en: {
+    heading: 'Our Team',
+  },
+  de: {
+    heading: 'Unser Team',
+  }
+}
+
 const Person = ({ name, role }: { name: string, role: Role }) => (
   <div className={tw('w-48')}>
     <div className={tw('font-semibold text-4xl text-white')}>
@@ -37,11 +53,12 @@ const Person = ({ name, role }: { name: string, role: Role }) => (
   </div>
 )
 
-const TeamSection = forwardRef<HTMLDivElement>(function TeamSection(_, ref) {
+const TeamSection = forwardRef<HTMLDivElement, PropsWithLanguage<TeamSectionLanguage>>(function TeamSection(props, ref) {
+  const language = useTranslation(props.language, defaultTeamSectionTranslations)
   return (
     <Section ref={ref} id="team">
       <div className={tw('flex justify-end')}>
-        <GridBox heading={<h1 className={tw('text-white text-5xl font-space font-bold pl-4 pb-4')}>Our Team</h1>}>
+        <GridBox heading={<h1 className={tw('text-white text-5xl font-space font-bold pl-4 pb-4')}>{language.heading}</h1>}>
           <div className={tw('w-fit grid grid-cols-2 gap-16')}>
             {teamMembers.map(({ name, role }, index) => <Person key={index} name={name} role={role} />)}
           </div>

--- a/landing-page/hooks/useLanguage.tsx
+++ b/landing-page/hooks/useLanguage.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import type { Dispatch, FunctionComponent, PropsWithChildren, SetStateAction } from 'react'
+
+const languages = ['en', 'de'] as const
+export type Languages = typeof languages[number]
+
+export const DEFAULT_LANGUAGE = 'en'
+
+export type LanguageContextValue = {
+  language: Languages,
+  setLanguage: Dispatch<SetStateAction<Languages>>
+}
+
+export const LanguageContext = createContext<LanguageContextValue>({ language: DEFAULT_LANGUAGE, setLanguage: (v) => v })
+
+export const useLanguage = () => useContext(LanguageContext)
+
+export const ProvideLanguage: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  const [language, setLanguage] = useState<Languages>(DEFAULT_LANGUAGE)
+
+  useEffect(() => {
+    const languagesToTestAgainst = Object.values(languages)
+
+    const matchingBrowserLanguages = window.navigator.languages
+      .map(language => languagesToTestAgainst.find((test) => language === test || language.split('-')[0] === test))
+      .filter(entry => entry !== undefined)
+
+    if (matchingBrowserLanguages.length === 0) return
+
+    const firstMatch = matchingBrowserLanguages[0] as Languages
+    console.log(`setting language to: ${firstMatch}`)
+    setLanguage(firstMatch)
+  }, [])
+
+  return (
+    <LanguageContext.Provider value={{
+      language,
+      setLanguage
+    }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}

--- a/landing-page/hooks/useTranslation.ts
+++ b/landing-page/hooks/useTranslation.ts
@@ -1,6 +1,19 @@
 import type { Languages } from '../hooks/useLanguage'
 import { useLanguage, DEFAULT_LANGUAGE } from '../hooks/useLanguage'
 
+/**
+ * Adds the `language` prop to the component props.
+ *
+ * @param Translation the type of the translation object
+ *
+ * @param Props the type of the component props, defaults to `Record<string, never>`,
+ *              if you don't expect any other props other than `language` and get an
+ *              error when using your component (because it uses `forwardRef` etc.)
+ *              you can try out `Record<string, unknown>`, this might resolve your
+ *              problem as `SomeType & never` is still `never` but `SomeType & unknown`
+ *              is `SomeType` which means that adding back props (like `ref` etc.)
+ *              works properly
+ */
 export type PropsWithLanguage<Translation, Props = Record<string, never>> = Props & {
   language?: Partial<Translation> | Languages
 }

--- a/landing-page/hooks/useTranslation.ts
+++ b/landing-page/hooks/useTranslation.ts
@@ -1,0 +1,20 @@
+import type { Languages } from '../hooks/useLanguage'
+import { useLanguage, DEFAULT_LANGUAGE } from '../hooks/useLanguage'
+
+export type PropsWithLanguage<Translation, Props = Record<string, never>> = Props & {
+  language?: Partial<Translation> | Languages
+}
+
+export const useTranslation = <Language extends Record<string, unknown>>(
+  languageProp: PropsWithLanguage<Language>['language'],
+  defaults: Record<Languages, Language>
+) => {
+  const { language: inferredLanguage } = useLanguage()
+  if (languageProp === undefined) {
+    return defaults[inferredLanguage]
+  } else if (typeof languageProp !== 'object') {
+    return defaults[languageProp as Languages]
+  } else {
+    return Object.assign(defaults[DEFAULT_LANGUAGE], languageProp as Partial<Language>)
+  }
+}

--- a/landing-page/pages/_app.tsx
+++ b/landing-page/pages/_app.tsx
@@ -5,6 +5,7 @@ import { Inter, Space_Grotesk as SpaceGrotesk } from '@next/font/google'
 import { tw } from '@twind/core'
 import withNextApp from '../twind/next/app'
 import { config } from '../twind.config'
+import { ProvideLanguage } from '../hooks/useLanguage'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -29,10 +30,12 @@ function MyApp({ Component, pageProps }: AppProps) {
           }
         `}</style>
       </Head>
-      <div className={tw('font-sans')}>
-        <Component {...pageProps} />
-        <Toaster />
-      </div>
+      <ProvideLanguage>
+        <div className={tw('font-sans')}>
+          <Component {...pageProps} />
+          <Toaster />
+        </div>
+      </ProvideLanguage>
     </>
   )
 }


### PR DESCRIPTION
This aims to add intl / i18n / internationalization support to the landing page

What is still missing:
- [ ] a few translations here and there
- [ ] layout fixes where different translations have given elements different sizes per language
- [ ] language switching using some kind of UI
- [ ] persisting language choices