### PR TITLE
fix: use consistent title

### DIFF
--- a/tasks/pages/_app.tsx
+++ b/tasks/pages/_app.tsx
@@ -26,7 +26,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     <ProvideLanguage>
       <BrowserView>
         <Head>
-          <title>Dashboard</title>
+          <title>helpwave tasks</title>
           <style>{`
           :root {
             --font-inter: ${inter.style.fontFamily};

--- a/tasks/pages/_app.tsx
+++ b/tasks/pages/_app.tsx
@@ -8,7 +8,7 @@ import { config } from '@helpwave/common/twind/config'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserView, MobileView } from 'react-device-detect'
 import MobileInterceptor from '../components/MobileInterceptor'
-import titleWrapper from '../utils/titleWrapper';
+import titleWrapper from '../utils/titleWrapper'
 
 const inter = Inter({
   subsets: ['latin'],

--- a/tasks/pages/_app.tsx
+++ b/tasks/pages/_app.tsx
@@ -8,6 +8,7 @@ import { config } from '@helpwave/common/twind/config'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserView, MobileView } from 'react-device-detect'
 import MobileInterceptor from '../components/MobileInterceptor'
+import titleWrapper from '../utils/titleWrapper';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -26,7 +27,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     <ProvideLanguage>
       <BrowserView>
         <Head>
-          <title>helpwave tasks</title>
+          <title>{titleWrapper()}</title>
           <style>{`
           :root {
             --font-inter: ${inter.style.fontFamily};

--- a/tasks/pages/_document.tsx
+++ b/tasks/pages/_document.tsx
@@ -1,6 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import withNextDocument from '@helpwave/common/twind/next/document'
 import { config } from '@helpwave/common/twind/config'
+import titleWrapper from '../utils/titleWrapper';
 
 class MyDocument extends Document {
   render() {
@@ -9,8 +10,9 @@ class MyDocument extends Document {
         <Head>
           <link rel="icon" href="/favicon.svg" />
           <meta name="description" content="Next generation healthcare software approach!" />
-          <meta name="og:title" property="og:title" content="helpwave" />
+          <meta name="og:title" property="og:title" content="helpwave tasks" />
           <meta property="og:description" content="Next generation healthcare software approach!" />
+          <title>{titleWrapper()}</title>
         </Head>
         <body>
           <Main />

--- a/tasks/pages/_document.tsx
+++ b/tasks/pages/_document.tsx
@@ -1,7 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import withNextDocument from '@helpwave/common/twind/next/document'
 import { config } from '@helpwave/common/twind/config'
-import titleWrapper from '../utils/titleWrapper';
+import titleWrapper from '../utils/titleWrapper'
 
 class MyDocument extends Document {
   render() {

--- a/tasks/pages/index.tsx
+++ b/tasks/pages/index.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router'
 import { WardServiceClient } from '../generated/Ward_svcServiceClientPb'
 import { CreateWardRequest, GetWardRequest } from '../generated/ward_svc_pb'
 import { PageWithHeader } from '../components/layout/PageWithHeader'
-import titleWrapper from '../utils/titleWrapper';
+import titleWrapper from '../utils/titleWrapper'
 
 const Home: NextPage = () => {
   const router = useRouter()

--- a/tasks/pages/index.tsx
+++ b/tasks/pages/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import { WardServiceClient } from '../generated/Ward_svcServiceClientPb'
 import { CreateWardRequest, GetWardRequest } from '../generated/ward_svc_pb'
 import { PageWithHeader } from '../components/layout/PageWithHeader'
+import titleWrapper from '../utils/titleWrapper';
 
 const Home: NextPage = () => {
   const router = useRouter()
@@ -51,7 +52,7 @@ const Home: NextPage = () => {
   return (
       <PageWithHeader>
         <Head>
-          <title>helpwave tasks</title>
+          <title>{titleWrapper()}</title>
         </Head>
 
         <h1 className={tw('text-3xl font-bold underline')}>

--- a/tasks/pages/index.tsx
+++ b/tasks/pages/index.tsx
@@ -51,7 +51,7 @@ const Home: NextPage = () => {
   return (
       <PageWithHeader>
         <Head>
-          <title>Create Next App</title>
+          <title>helpwave tasks</title>
         </Head>
 
         <h1 className={tw('text-3xl font-bold underline')}>

--- a/tasks/pages/login.tsx
+++ b/tasks/pages/login.tsx
@@ -13,7 +13,7 @@ import type { Languages } from '@helpwave/common/hooks/useLanguage'
 import { useTranslation } from '@helpwave/common/hooks/useTranslation'
 import type { PropsWithLanguage } from '@helpwave/common/hooks/useTranslation'
 import HelpwaveLogo from '../icons/Helpwave'
-import titleWrapper from '../utils/titleWrapper';
+import titleWrapper from '../utils/titleWrapper'
 
 type LoginTranslation = {
   signInHeader: string,

--- a/tasks/pages/login.tsx
+++ b/tasks/pages/login.tsx
@@ -88,7 +88,7 @@ const LoginPage: NextPage<PropsWithLanguage<LoginTranslation>> = (props) => {
   return (
     <div>
         <Head>
-          <title>Login</title>
+          <title>Login - helpwave tasks</title>
         </Head>
         <div className={tw('flex items-center justify-center py-12 px-4')}>
           <div className={tw('w-full max-w-md space-y-8')}>

--- a/tasks/pages/login.tsx
+++ b/tasks/pages/login.tsx
@@ -13,6 +13,7 @@ import type { Languages } from '@helpwave/common/hooks/useLanguage'
 import { useTranslation } from '@helpwave/common/hooks/useTranslation'
 import type { PropsWithLanguage } from '@helpwave/common/hooks/useTranslation'
 import HelpwaveLogo from '../icons/Helpwave'
+import titleWrapper from '../utils/titleWrapper';
 
 type LoginTranslation = {
   signInHeader: string,
@@ -88,7 +89,7 @@ const LoginPage: NextPage<PropsWithLanguage<LoginTranslation>> = (props) => {
   return (
     <div>
         <Head>
-          <title>Login - helpwave tasks</title>
+          <title>{titleWrapper('Login')}</title>
         </Head>
         <div className={tw('flex items-center justify-center py-12 px-4')}>
           <div className={tw('w-full max-w-md space-y-8')}>

--- a/tasks/pages/organizations.tsx
+++ b/tasks/pages/organizations.tsx
@@ -73,7 +73,7 @@ const OrganizationsPage: NextPage = ({ language }: PropsWithLanguage<Organizatio
       crumbs={[{ display: translation.organizations, link: '/organizations' }]}
     >
       <Head>
-        <title>{translation.organizations}</title>
+        <title>{translation.organizations} ~ helpwave tasks</title>
       </Head>
       <TwoColumn
         left={(

--- a/tasks/pages/organizations.tsx
+++ b/tasks/pages/organizations.tsx
@@ -14,7 +14,7 @@ import {
   useUpdateMutation
 } from '../mutations/organization_mutations'
 import { PageWithHeader } from '../components/layout/PageWithHeader'
-import titleWrapper from '../utils/titleWrapper';
+import titleWrapper from '../utils/titleWrapper'
 
 type OrganizationsPageTranslation = {
   organizations: string

--- a/tasks/pages/organizations.tsx
+++ b/tasks/pages/organizations.tsx
@@ -14,6 +14,7 @@ import {
   useUpdateMutation
 } from '../mutations/organization_mutations'
 import { PageWithHeader } from '../components/layout/PageWithHeader'
+import titleWrapper from '../utils/titleWrapper';
 
 type OrganizationsPageTranslation = {
   organizations: string
@@ -73,7 +74,7 @@ const OrganizationsPage: NextPage = ({ language }: PropsWithLanguage<Organizatio
       crumbs={[{ display: translation.organizations, link: '/organizations' }]}
     >
       <Head>
-        <title>{translation.organizations} ~ helpwave tasks</title>
+        <title>{titleWrapper(translation.organizations)}</title>
       </Head>
       <TwoColumn
         left={(

--- a/tasks/pages/organizations/[uuid].tsx
+++ b/tasks/pages/organizations/[uuid].tsx
@@ -14,6 +14,7 @@ import {
 import { WardDisplay } from '../../components/layout/WardDisplay'
 import { WardDetail } from '../../components/layout/WardDetails'
 import { PageWithHeader } from '../../components/layout/PageWithHeader'
+import titleWrapper from '../../utils/titleWrapper';
 
 type WardsPageTranslation = {
   wards: string,
@@ -76,7 +77,7 @@ const WardsPage: NextPage = ({ language }: PropsWithLanguage<WardsPageTranslatio
       ]}
     >
       <Head>
-        <title>{translation.wards} ~ helpwave tasks</title>
+        <title>{titleWrapper(translation.wards)}</title>
       </Head>
 
       <TwoColumn

--- a/tasks/pages/organizations/[uuid].tsx
+++ b/tasks/pages/organizations/[uuid].tsx
@@ -76,7 +76,7 @@ const WardsPage: NextPage = ({ language }: PropsWithLanguage<WardsPageTranslatio
       ]}
     >
       <Head>
-        <title>{translation.wards}</title>
+        <title>{translation.wards} ~ helpwave tasks</title>
       </Head>
 
       <TwoColumn

--- a/tasks/pages/organizations/[uuid].tsx
+++ b/tasks/pages/organizations/[uuid].tsx
@@ -14,7 +14,7 @@ import {
 import { WardDisplay } from '../../components/layout/WardDisplay'
 import { WardDetail } from '../../components/layout/WardDetails'
 import { PageWithHeader } from '../../components/layout/PageWithHeader'
-import titleWrapper from '../../utils/titleWrapper';
+import titleWrapper from '../../utils/titleWrapper'
 
 type WardsPageTranslation = {
   wards: string,

--- a/tasks/pages/profile.tsx
+++ b/tasks/pages/profile.tsx
@@ -10,7 +10,7 @@ import { Input, noop } from '../components/user_input/Input'
 import { Avatar } from '../components/Avatar'
 import { UserCard } from '../components/cards/UserCard'
 import { PageWithHeader } from '../components/layout/PageWithHeader'
-import titleWrapper from '../utils/titleWrapper';
+import titleWrapper from '../utils/titleWrapper'
 
 const Section = ({ title, children }: PropsWithChildren<{ title: string }>) => (
   <div className={tw('flex')}>

--- a/tasks/pages/profile.tsx
+++ b/tasks/pages/profile.tsx
@@ -54,7 +54,7 @@ const ProfilePage: NextPage = () => {
   return (
     <PageWithHeader>
       <Head>
-        <title>Settings</title>
+        <title>Profile ~ helpwave tasks</title>
       </Head>
 
       <div className={tw('p-4 w-full h-full')}>

--- a/tasks/pages/profile.tsx
+++ b/tasks/pages/profile.tsx
@@ -10,6 +10,7 @@ import { Input, noop } from '../components/user_input/Input'
 import { Avatar } from '../components/Avatar'
 import { UserCard } from '../components/cards/UserCard'
 import { PageWithHeader } from '../components/layout/PageWithHeader'
+import titleWrapper from '../utils/titleWrapper';
 
 const Section = ({ title, children }: PropsWithChildren<{ title: string }>) => (
   <div className={tw('flex')}>
@@ -54,7 +55,7 @@ const ProfilePage: NextPage = () => {
   return (
     <PageWithHeader>
       <Head>
-        <title>Profile ~ helpwave tasks</title>
+        <title>{titleWrapper('Profile')}</title>
       </Head>
 
       <div className={tw('p-4 w-full h-full')}>

--- a/tasks/pages/settings.tsx
+++ b/tasks/pages/settings.tsx
@@ -28,7 +28,7 @@ const SettingsPage: NextPage = () => {
   return (
     <PageWithHeader>
       <Head>
-        <title>Settings</title>
+        <title>Settings ~ helpwave tasks</title>
       </Head>
 
       <div className={tw('p-4 w-full h-full')}>

--- a/tasks/pages/settings.tsx
+++ b/tasks/pages/settings.tsx
@@ -5,6 +5,8 @@ import Head from 'next/head'
 import { tw, tx } from '@helpwave/common/twind/index'
 import CheckIcon from '../icons/Check'
 import { PageWithHeader } from '../components/layout/PageWithHeader'
+import titleWrapper from '../utils/titleWrapper';
+import { PropsWithLanguage, useTranslation } from '@helpwave/common/hooks/useTranslation';
 
 const tabs = [
   'general', 'account'
@@ -22,13 +24,27 @@ const SidebarItem = ({ text, icon, active, onClick }: { text: string, icon: Reac
   </li>
 )
 
-const SettingsPage: NextPage = () => {
+type SettingsTranslation = {
+  settings: string
+}
+
+const defaultSettingsPageTranslation = {
+  en: {
+    settings: 'Settings'
+  },
+  de: {
+    settings: 'Einstellungen'
+  }
+}
+
+const SettingsPage: NextPage = ({ language }: PropsWithLanguage<SettingsTranslation>) => {
+  const translation = useTranslation(language, defaultSettingsPageTranslation)
   const [activeTab, setActiveTab] = useState<typeof tabs[number]>('general')
 
   return (
     <PageWithHeader>
       <Head>
-        <title>Settings ~ helpwave tasks</title>
+        <title>{titleWrapper(translation.settings)}</title>
       </Head>
 
       <div className={tw('p-4 w-full h-full')}>

--- a/tasks/pages/settings.tsx
+++ b/tasks/pages/settings.tsx
@@ -5,8 +5,9 @@ import Head from 'next/head'
 import { tw, tx } from '@helpwave/common/twind/index'
 import CheckIcon from '../icons/Check'
 import { PageWithHeader } from '../components/layout/PageWithHeader'
-import titleWrapper from '../utils/titleWrapper';
-import { PropsWithLanguage, useTranslation } from '@helpwave/common/hooks/useTranslation';
+import titleWrapper from '../utils/titleWrapper'
+import type { PropsWithLanguage } from '@helpwave/common/hooks/useTranslation'
+import { useTranslation } from '@helpwave/common/hooks/useTranslation'
 
 const tabs = [
   'general', 'account'

--- a/tasks/pages/ward/[uuid].tsx
+++ b/tasks/pages/ward/[uuid].tsx
@@ -95,7 +95,7 @@ const WardOverview: NextPage = ({ language }: PropsWithLanguage<WardOverviewTran
       ]}
     >
       <Head>
-        <title>{translation.roomOverview}</title>
+        <title>{translation.roomOverview} ~ helpwave tasks</title>
       </Head>
       <TwoColumn
         left={(

--- a/tasks/pages/ward/[uuid].tsx
+++ b/tasks/pages/ward/[uuid].tsx
@@ -16,6 +16,7 @@ import {
 import { RoomOverview } from '../../components/RoomOverview'
 import { PatientDetail } from '../../components/layout/PatientDetails'
 import { PageWithHeader } from '../../components/layout/PageWithHeader'
+import titleWrapper from '../../utils/titleWrapper';
 
 type WardOverviewTranslation = {
   beds: string,
@@ -95,7 +96,7 @@ const WardOverview: NextPage = ({ language }: PropsWithLanguage<WardOverviewTran
       ]}
     >
       <Head>
-        <title>{translation.roomOverview} ~ helpwave tasks</title>
+        <title>{titleWrapper(translation.roomOverview)}</title>
       </Head>
       <TwoColumn
         left={(

--- a/tasks/pages/ward/[uuid].tsx
+++ b/tasks/pages/ward/[uuid].tsx
@@ -16,7 +16,7 @@ import {
 import { RoomOverview } from '../../components/RoomOverview'
 import { PatientDetail } from '../../components/layout/PatientDetails'
 import { PageWithHeader } from '../../components/layout/PageWithHeader'
-import titleWrapper from '../../utils/titleWrapper';
+import titleWrapper from '../../utils/titleWrapper'
 
 type WardOverviewTranslation = {
   beds: string,

--- a/tasks/utils/titleWrapper.ts
+++ b/tasks/utils/titleWrapper.ts
@@ -1,0 +1,5 @@
+const defaultTitle = 'helpwave tasks'
+
+const titleWrapper = (title?: string) => title ? `${title} ~ ${defaultTitle}` : defaultTitle
+
+export default titleWrapper


### PR DESCRIPTION
Use `helpwave tasks` or the suffix `~ helpwave tasks`

Closes #202 