### PR TITLE
feat: replace green confirm button with red color

### DIFF
--- a/tasks/components/layout/OrganizationDetails.tsx
+++ b/tasks/components/layout/OrganizationDetails.tsx
@@ -8,7 +8,7 @@ import type { Role } from '../OrganizationMemberList'
 import { OrganizationMemberList } from '../OrganizationMemberList'
 import { ColumnTitle } from '../ColumnTitle'
 import { Button } from '../Button'
-import { ConfirmDialog } from '../modals/ConfirmDialog'
+import { ConfirmDialog, ConfirmDialogType } from '../modals/ConfirmDialog'
 
 type OrganizationDetailTranslation = {
   organizationDetail: string,
@@ -103,6 +103,7 @@ export const OrganizationDetail = ({
           setIsShowingConfirmDialog(false)
           onDelete(newOrganization)
         }}
+        type={ConfirmDialogType.Negative}
       />
       <ColumnTitle title={translation.organizationDetail}/>
       <OrganizationForm

--- a/tasks/components/layout/OrganizationDetails.tsx
+++ b/tasks/components/layout/OrganizationDetails.tsx
@@ -8,7 +8,7 @@ import type { Role } from '../OrganizationMemberList'
 import { OrganizationMemberList } from '../OrganizationMemberList'
 import { ColumnTitle } from '../ColumnTitle'
 import { Button } from '../Button'
-import { ConfirmDialog, ConfirmDialogType } from '../modals/ConfirmDialog'
+import { ConfirmDialog } from '../modals/ConfirmDialog'
 
 type OrganizationDetailTranslation = {
   organizationDetail: string,
@@ -103,7 +103,7 @@ export const OrganizationDetail = ({
           setIsShowingConfirmDialog(false)
           onDelete(newOrganization)
         }}
-        type={ConfirmDialogType.Negative}
+        type="negative"
       />
       <ColumnTitle title={translation.organizationDetail}/>
       <OrganizationForm

--- a/tasks/components/modals/ConfirmDialog.tsx
+++ b/tasks/components/modals/ConfirmDialog.tsx
@@ -12,11 +12,7 @@ type ConfirmDialogTranslation = {
   decline: string
 }
 
-export enum ConfirmDialogType{
-  Positive = 'Positive',
-  Neutral = 'Neutral',
-  Negative = 'Negative'
-}
+export type ConfirmDialogType = 'positive' | 'negative' | 'neutral'
 
 const defaultConfirmDialogTranslation = {
   en: {
@@ -50,10 +46,9 @@ export const ConfirmDialog = ({
   onConfirm,
   onDecline,
   onBackgroundClick,
-  type = ConfirmDialogType.Positive
+  type = 'positive'
 }: PropsWithLanguage<ConfirmDialogTranslation, PropsWithChildren<ConfirmDialogProps>>) => {
   const translation = useTranslation(language, defaultConfirmDialogTranslation)
-  const confirmationButtonColor = type === ConfirmDialogType.Positive ? 'positive' : type === ConfirmDialogType.Negative ? 'negative' : 'neutral'
   return (
     <Modal
       isOpen={isOpen}
@@ -72,7 +67,7 @@ export const ConfirmDialog = ({
             {translation.decline}
           </Button>
         )}
-        <Button autoFocus color={confirmationButtonColor} onClick={onConfirm}>
+        <Button autoFocus color={type} onClick={onConfirm}>
           {translation.confirm}
         </Button>
       </div>

--- a/tasks/components/modals/ConfirmDialog.tsx
+++ b/tasks/components/modals/ConfirmDialog.tsx
@@ -12,6 +12,12 @@ type ConfirmDialogTranslation = {
   decline: string
 }
 
+export enum ConfirmDialogType{
+  Positive = 'Positive',
+  Neutral = 'Neutral',
+  Negative = 'Negative'
+}
+
 const defaultConfirmDialogTranslation = {
   en: {
     confirm: 'Confirm',
@@ -30,7 +36,8 @@ type ConfirmDialogProps = ModalProps & {
   requireAnswer?: boolean,
   onCancel?: () => void,
   onConfirm: () => void,
-  onDecline?: () => void
+  onDecline?: () => void,
+  type: ConfirmDialogType
 }
 
 export const ConfirmDialog = ({
@@ -43,8 +50,10 @@ export const ConfirmDialog = ({
   onConfirm,
   onDecline,
   onBackgroundClick,
+  type = ConfirmDialogType.Positive
 }: PropsWithLanguage<ConfirmDialogTranslation, PropsWithChildren<ConfirmDialogProps>>) => {
   const translation = useTranslation(language, defaultConfirmDialogTranslation)
+  const confirmationButtonColor = type === ConfirmDialogType.Positive ? 'positive' : type === ConfirmDialogType.Negative ? 'negative' : 'neutral'
   return (
     <Modal
       isOpen={isOpen}
@@ -63,7 +72,7 @@ export const ConfirmDialog = ({
             {translation.decline}
           </Button>
         )}
-        <Button autoFocus color="positive" onClick={onConfirm}>
+        <Button autoFocus color={confirmationButtonColor} onClick={onConfirm}>
           {translation.confirm}
         </Button>
       </div>


### PR DESCRIPTION
This pull request replaces the green confirm button with red color

Closes https://github.com/helpwave/web/issues/245

Testing instructions:

- Go to the organizations' page and click the edit icon of any organization from the list to see organization info.
- Under the `Danger Zone` section click on the `Delete Organization` button you will see a confirmation dialogue and it should contain a confirmation button in red color instead of green.

Additional notes:

- Refactored the confirmation dialogue to support different types of confirmations. The default confirmation dialogue is `Positive Action`.