### PR TITLE
fix: deployment due to next patch

### DIFF
--- a/Dockerfile.tasks
+++ b/Dockerfile.tasks
@@ -39,4 +39,5 @@ COPY --from=build --chown=nextjs:nodejs /web/tasks/build/static ./tasks/build/st
 
 EXPOSE 80
 ENV PORT 80
+ENV HOSTNAME 0.0.0.0
 CMD ["node", "tasks/server.js"]

--- a/tasks/fly.toml
+++ b/tasks/fly.toml
@@ -3,6 +3,16 @@ primary_region = "ams"
 [build]
   dockerfile = "../Dockerfile.tasks"
 
+[deploy]
+  strategy = "bluegreen"
+
 [http_service]
   internal_port = 80
   force_https = true
+
+[[http_service.checks]]
+  grace_period = "10s"
+  interval = "30s"
+  method = "GET"
+  timeout = "5s"
+  path = "/"

--- a/tasks/utils/oauth.ts
+++ b/tasks/utils/oauth.ts
@@ -99,7 +99,8 @@ const buildAuthorizationUrl = (params: {
 
 export const getAuthorizationUrl = async (): Promise<string> => {
   if (config.fakeTokenEnable) {
-    const url = new URL(config.oauth.redirectUri)
+    const url = new URL(window.location.origin)
+    url.pathname = '/auth/callback'
     url.searchParams.set('fake_token', config.fakeToken)
     return url.toString()
   }


### PR DESCRIPTION
Due to [some updates of Next.js](https://github.com/vercel/next.js/pull/53131) we need to set the hostname explicit. Also, the redirect url when fake tokens are enabled gets now dynamically resolved.