### PR TITLE
ci: add preview via fly

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,81 @@
+name: Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+concurrency:
+  group: pr-${{ github.event.number }}
+
+jobs:
+
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.changes.outputs.all_changed_files }}
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes in migrations
+        id: changes
+        uses: tj-actions/changed-files@v37
+        with:
+          json: "true"
+          escape_json: "false"
+          dir_names: "true"
+          dir_names_exclude_current_dir: "true"
+          dir_names_max_depth: 1
+          # Modify the following list of directories with new projects
+          files: |
+            tasks/**
+
+      - name: Summarize changes
+        run: |
+          echo "projects: $projects" >> $GITHUB_STEP_SUMMARY
+        env:
+          projects: ${{ steps.changes.outputs.all_changed_files }}
+
+  preview:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.projects != '[]'
+    strategy:
+      matrix:
+        project: ${{ fromJson(needs.detect-changes.outputs.projects) }}
+# TODO: Migrate to GitHub Environment
+#    environment:
+#      name: pr-${{ github.event.number }}-${{ matrix.project }}
+#      url: ${{ steps.deploy.outputs.url }}
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      FLY_REGION: ams
+      FLY_ORG: helpwave-staging
+    steps:
+
+      - uses: actions/checkout@v3
+
+      # --copy-config uses a fly.toml from the current working directory
+      # as a base configuration for the new app
+      - name: Prepare fly.toml for `fly launch --copy-config`
+        run: |
+          cp ${{ matrix.project }}/fly.toml .
+          sed -i "s/\.\.\/Dockerfile/Dockerfile/g" fly.toml
+
+      - name: Deploy preview to Fly
+        id: deploy
+        uses: superfly/fly-pr-review-apps@1.0.0
+        with:
+          name: pr-${{ github.event.number }}-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ matrix.project }}
+          config: ${{ matrix.project }}/fly.toml
+
+      - name: Comment preview url to pull-request
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          comment_tag: preview_${{ matrix.project }}
+          mode: ${{ github.event.action == 'closed' && 'delete' || 'upsert' }}
+          message: |
+            ### Preview of ${{ matrix.project }}
+            ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
This pull-request introduces the ability to preview projects of this monorepo on Fly.io. The solution proposed in https://github.com/helpwave/web/pull/351 adopts `next-on-pages`. I am following this repository closely, it seems like that this project is unstable.

Therefore, I decided to go with https://github.com/superfly/fly-pr-review-apps. Projects inside this monorepo, that are already deployed via Fly.io are now able to deploy a preview environment in our `helpwave-staging` orga.

I've tested the mentioned deployment via GitHub environments (a first-class feature to show the deployment state of branches), but this requires clean-up of already merged deployments. https://github.com/strumwolf/delete-deployment-environment should handle this, but I couldn't get it to run. Successful execution, no action. We're now just commenting the preview URL into the pr for now. _TODO_

### Testing

_See comment below_

Closes #164
Closes #351