### PR TITLE
ci: make preview configurable

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -51,8 +51,8 @@ jobs:
 #      url: ${{ steps.deploy.outputs.url }}
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      FLY_REGION: ams
-      FLY_ORG: helpwave-staging
+      FLY_REGION: ${{ vars.PREVIEW_FLY_REGION || ams }}
+      FLY_ORG: ${{ vars.PREVIEW_FLY_ORGANIZATION }}
     steps:
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
We are moving all previews to a separate organization on Fly.
The envs are set to:
- PREVIEW_FLY_ORGANIZATION: helpwave-preview
- PREVIEW_FLY_REGION: cdg