### PR TITLE
fix: hide unready product pages from products dropdown

### DIFF
--- a/landing-page/components/Header.tsx
+++ b/landing-page/components/Header.tsx
@@ -25,14 +25,6 @@ const items: SubLinkType[] = [
       {
         name: 'tasks',
         url: '/tasks',
-      },
-      {
-        name: 'impulse',
-        url: '/impulse',
-      },
-      {
-        name: 'cloud',
-        url: '/cloud',
       }
     ]
   },


### PR DESCRIPTION
Context https://github.com/helpwave/web/pull/854