### PR TITLE
fix: centers the create button within the form in new task template

### DIFF
--- a/tasks/components/layout/TaskTemplateDetails.tsx
+++ b/tasks/components/layout/TaskTemplateDetails.tsx
@@ -170,7 +170,7 @@ export const TaskTemplateDetails = ({
       <div className={tx('flex flex-row mt-12',
         {
           'justify-between': !isCreatingNewTemplate,
-          'justify-end': isCreatingNewTemplate,
+          'justify-center': isCreatingNewTemplate,
         })}
       >
         <Button


### PR DESCRIPTION
## Which issues does this pull request close?
closes #1114 Spelling
