### PR TITLE
ci: run preview ci when lib changes

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -31,6 +31,7 @@ jobs:
           # Modify the following list of directories with new projects
           files: |
             tasks/**
+            lib/**
 
       - name: Summarize changes
         run: |


### PR DESCRIPTION
Our preview CI for helpwave tasks does not run when only `lib/**` has changes.
Example: https://github.com/helpwave/web/pull/1146